### PR TITLE
Member request

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The account/rank pairs which the Technical Committee should introduce.
 | `kianenigma` | `HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1` | 4 |
 | `xlc` | `HyBryanRsB1GGKa9ZfqvRc3XpTDipYyRvxNNyZYfWFcenhd` | 4 |
 | `ordian` | `GAWwkmjbLhM5pnAVbdZEkwd3QjHE7kaxJSCi3Ec91Q3QSDW` | 3 |
-| `seunlanlege` | `12EXcpt1CwnSAF9d7YWrh91bQw6R5wmCpJUXPWi7vn2CZFpJ` | 3 |
 | `drahnr` | `H25aCspunTUqAt4D1gC776vKZ8FX3MvQJ3Jde6qDXPQaFxk` | 3 |
 | `NikVolf` | `GtLQoW4ZqcjExMPq6qB22bYc6NaX1yMzRuGWpSRiHqnzRb9` | 3 |
 | `athei` | `G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y` | 3 |
@@ -23,6 +22,7 @@ The account/rank pairs which the Technical Committee should introduce.
 | `KiChjang` | `GA3yPifemubFga7sTSFtLY2KFFiSRp6Bb8w31FS4xqgAvCz` | 2 |
 | `shaunxw` | `HxhDbS3grLurk1dhDgPiuDaRowHY1xHCU8Vu8on3fdg85tx` | 2 |
 | `koute` | `HTk3eccL7WBkiyxz1gBcqQRghsJigoDMD7mnQaz1UAbMpQV` | 2 |
+| `seunlanlege` | `12EXcpt1CwnSAF9d7YWrh91bQw6R5wmCpJUXPWi7vn2CZFpJ` | 2 |
 | `AurevoirXavier` | `GfbnnEgRU94n9ed4RFZ6Z9dBAWs5obykigJSwXKU9hsT2uU` | 1 |
 | `gilescope` | `Hj44XnjZui7SQ3A5eBMoJFa4H4nVhiyWnL2i2xw5f1YqzRX` | 1 |
 | `ggwpez` | `Ea6jhP5gF4r7NqhkEoAXJDgSgYpNQNaTYU6gPsrEGfctaKR` | 1 |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The account/rank pairs which the Technical Committee should introduce.
 | `kianenigma` | `HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1` | 4 |
 | `xlc` | `HyBryanRsB1GGKa9ZfqvRc3XpTDipYyRvxNNyZYfWFcenhd` | 4 |
 | `ordian` | `GAWwkmjbLhM5pnAVbdZEkwd3QjHE7kaxJSCi3Ec91Q3QSDW` | 3 |
+| `seunlanlege` | `12EXcpt1CwnSAF9d7YWrh91bQw6R5wmCpJUXPWi7vn2CZFpJ` | 3 |
 | `drahnr` | `H25aCspunTUqAt4D1gC776vKZ8FX3MvQJ3Jde6qDXPQaFxk` | 3 |
 | `NikVolf` | `GtLQoW4ZqcjExMPq6qB22bYc6NaX1yMzRuGWpSRiHqnzRb9` | 3 |
 | `athei` | `G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y` | 3 |


### PR DESCRIPTION
I'm humbly requesting to be added as rank ~Dan III~ (since centauri isn't live yet), Dan II. 

I joined parity in 2018, where I got started by working on the parity-ethereum client, But switched teams in 2019 from parity-ethereum to the substrate client team. Where i've made contributions to core pieces of substrate chains ranging from consensus, rpc, transaction pool, simulation testing (manual-seal which is used by parachain teams like moonbeam, astar and acala) and api design.

### Pull requests to substrate here:

https://github.com/paritytech/substrate/pulls?page=1&q=is%3Apr+author%3Aseunlanlege+is%3Amerged

### Featurettes on substrate seminar

https://www.youtube.com/watch?v=uhkV0jAcWDY
https://www.youtube.com/watch?v=0FvcABti7yk

### Working in the parachain ecosystem

After leaving parity in 2021, I joined composable.finance where i lead the team responsible for the research and design of trustless bridges where we've implemented:

 - [x] Both a beefy and grandpa light client for the IBC protocol here: https://github.com/ComposableFi/centauri
- [x] IBC protocol implementation for substrate chains here: https://github.com/ComposableFi/composable/blob/centauri/code/parachain/frame/ibc/src/lib.rs
- [x] Chain agnostic IBC relayer implementation: https://github.com/ComposableFi/hyperspace

### Technical writing related to trustless bridging

https://medium.com/composable-finance/trustless-bridging-438a6e5c917a
https://medium.com/composable-finance/trustless-bridging-ii-byzantine-fault-tolerance-591e8b2d196e

This work will be used to bridge our picasso (kusama) parachain to our composable (polkadot) parachain, as well as bridge our parachains to NEAR, cosmos-sdk chains and ethereum and its rollups.

### Hobby Projects

In my spare time i like to hack on simulation testing, where i continue to maintain a simulation testing framework for substrate based on manual-seal here: 

https://github.com/polytope-labs/substrate-simnode